### PR TITLE
Destroy watcher when component is unmounted

### DIFF
--- a/index.js
+++ b/index.js
@@ -89,6 +89,10 @@ export const Watch = (Component) => class WatchedComponent extends React.Compone
 		});
 	}
 
+	componentWillUnmount () {
+		this.watcher.destroy()
+	}
+
 	lockWatcher () {
 		this.watcher.lock();
 	}


### PR DESCRIPTION
If the watcher is not destroyed, setState has potential to be called
after the component is unmounted.